### PR TITLE
Download manifest to local store

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,12 @@ impl Config {
                 continue
             }
 
+            // Skip lines starting with '#' or ';' to allow comments. This is
+            // consistent with systemd's comment syntax.
+            if line.starts_with("#") || line.starts_with(";") {
+                continue
+            }
+
             if let Some(n) = line.find('=') {
                 let key = &line[..n];
                 let value = &line[n + 1..];
@@ -139,6 +145,18 @@ mod test {
         ];
         let config = Config::parse(&config_lines).unwrap();
         assert_eq!(&config.restart_units[..], &["foo", "bar"]);
+    }
+
+    #[test]
+    pub fn parse_skips_comments() {
+        let config_lines = [
+            "Origin=https://images.example.com/app-foo",
+            "# This is a comment.",
+            "PublicKey=8+r5DKNN/cwI+h0oHxMtgdyND3S/5xDLHQu0hFUmq+g=",
+            "; This is also a comment.",
+            "Destination=/var/lib/images/app-foo",
+        ];
+        assert!(Config::parse(&config_lines).is_ok());
     }
 
     // TODO: Test error cases.

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,11 +10,11 @@ use base64;
 use error::{Error, Result};
 
 #[derive(Debug)]
-struct Config {
-    origin: String,
-    public_key: [u8; 32],
-    destination: PathBuf,
-    restart_units: Vec<String>,
+pub struct Config {
+    pub origin: String,
+    pub public_key: [u8; 32],
+    pub destination: PathBuf,
+    pub restart_units: Vec<String>,
 }
 
 fn parse_public_key(lineno: usize, key_base64: &str) -> Result<[u8; 32]> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,9 @@ pub enum Error {
     /// Signature verification failed.
     InvalidSignature,
 
+    /// Curl failed in some way.
+    DownloadError(String),
+
     /// IO error.
     IoError(io::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,9 @@ pub enum Error {
     /// Signature verification failed.
     InvalidSignature,
 
+    /// An operational error occurred.
+    OperationError(&'static str),
+
     /// Curl failed in some way.
     DownloadError(String),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,12 @@ pub enum Error {
     IoError(io::Error),
 }
 
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::IoError(err)
+    }
+}
+
 pub type Result<T> = result::Result<T, Error>;
 
 // TODO: Implement std::error::Error for Error.

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,0 +1,47 @@
+// Tako -- Take container image.
+// Copyright 2018 Arian van Putten, Ruud van Asseldonk, Tako Marks.
+
+//! Contains the main fetching logic (downloading manifests and images).
+
+use std::fs;
+use std::io;
+use std::io::{BufRead};
+
+use config::Config;
+use curl;
+use error::Result;
+use manifest::Manifest;
+
+fn load_config(config_fname: &str) -> Result<Config> {
+    let f = fs::File::open(config_fname)?;
+    let buf_reader = io::BufReader::new(f);
+    let mut lines = Vec::new();
+    for line in buf_reader.lines() {
+        lines.push(line?);
+    }
+    Config::parse(lines.iter())
+}
+
+/// Check for, download, and apply updates as given in the config.
+pub fn fetch(config_fname: &str) -> Result<()> {
+    let config = load_config(config_fname)?;
+    println!("config: {:?}", config);
+
+    let mut curl_handle = curl::Handle::new();
+
+    let mut uri = config.origin.to_string();
+    if !uri.ends_with("/") { uri.push('/'); }
+    uri.push_str("manifest");
+
+    let mut manifest_bytes = Vec::new();
+    curl_handle.download(&uri, |chunk| manifest_bytes.extend_from_slice(chunk))?;
+
+    let manifest = Manifest::parse(&manifest_bytes[..])?;
+    // TODO: Verify signature.
+
+    for entry in &manifest.entries {
+        println!("entry: {:?}", entry);
+    }
+
+    Ok(())
+}

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -15,11 +15,8 @@ use manifest::Manifest;
 fn load_config(config_fname: &str) -> Result<Config> {
     let f = fs::File::open(config_fname)?;
     let buf_reader = io::BufReader::new(f);
-    let mut lines = Vec::new();
-    for line in buf_reader.lines() {
-        lines.push(line?);
-    }
-    Config::parse(lines.iter())
+    let lines: io::Result<Vec<String>> = buf_reader.lines().collect();
+    Config::parse(lines?.iter())
 }
 
 /// Load a locally stored manifest.

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -5,11 +5,11 @@
 
 use std::fs;
 use std::io;
-use std::io::{BufRead};
+use std::io::{BufRead, Read, Write};
 
 use config::Config;
 use curl;
-use error::Result;
+use error::{Error, Result};
 use manifest::Manifest;
 
 fn load_config(config_fname: &str) -> Result<Config> {
@@ -22,10 +22,53 @@ fn load_config(config_fname: &str) -> Result<Config> {
     Config::parse(lines.iter())
 }
 
+/// Load a locally stored manifest.
+fn load_local_manifest(config: &Config) -> Result<Option<Manifest>> {
+    // Open the current manifest. If it does not exist that is not an error.
+    let mut path = config.destination.clone();
+    path.push("manifest");
+    let f = match fs::File::open(path) {
+        Err(ref e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        other => other?,
+    };
+
+    let mut buf_reader = io::BufReader::new(f);
+    let mut manifest_bytes = Vec::new();
+    buf_reader.read_to_end(&mut manifest_bytes)?;
+
+    Ok(Some(Manifest::parse(&manifest_bytes[..])?))
+}
+
+/// Store a manifest locally. Writes first and then swaps the file.
+fn store_local_manifest(config: &Config, bytes: &[u8]) -> Result<()> {
+    let mut path_tmp = config.destination.clone();
+    let mut path_final = config.destination.clone();
+    path_tmp.push("manifest.new");
+    path_final.push("manifest");
+
+    // First write the entire manifest to a new file.
+    let f = fs::File::create(&path_tmp)?;
+    let mut buf_writer = io::BufWriter::new(f);
+    buf_writer.write_all(bytes)?;
+
+    // Then rename it over the old manifest.
+    fs::rename(path_tmp, path_final)?;
+
+    Ok(())
+}
+
 /// Check for, download, and apply updates as given in the config.
 pub fn fetch(config_fname: &str) -> Result<()> {
     let config = load_config(config_fname)?;
     println!("config: {:?}", config);
+
+    // TODO: If we fail to load this manifest, it is not clear to the user
+    // that this is about the local manifest, rather than the remote one. We
+    // should extend the error type to include this info.
+    // TODO: In the case of a key rotation, after updating the key in the
+    // config, we would no longer be able to load the currently stored manifest.
+    // How to deal with that? Allow multiple public keys in the config?
+    let local_manifest = load_local_manifest(&config)?;
 
     let mut curl_handle = curl::Handle::new();
 
@@ -36,10 +79,24 @@ pub fn fetch(config_fname: &str) -> Result<()> {
     let mut manifest_bytes = Vec::new();
     curl_handle.download(&uri, |chunk| manifest_bytes.extend_from_slice(chunk))?;
 
-    let manifest = Manifest::parse(&manifest_bytes[..])?;
-    // TODO: Verify signature.
+    let remote_manifest = Manifest::parse(&manifest_bytes[..])?;
 
-    for entry in &manifest.entries {
+    // If there was a local manifest already, it must be a subset of the remote
+    // one. Otherwise, if we overwrite the local manifest, that would remove
+    // entries, and those entries might exist on disk -- one of them might be
+    // the image currently in use. If we would erase that from the manifest,
+    // then we would no longer know what that image is. So bail out.
+    if Some(false) == local_manifest.map(|m| m.is_subset_of(&remote_manifest)) {
+        let msg = "The remote manifest is not a superset of the local manifest. Rejecting remote manifest.";
+        return Err(Error::OperationError(msg))
+    }
+
+    // Store the manifest locally before we continue. It doesn't hurt to have
+    // more entries in there even if we don't have the images yet. But on the
+    // other hand, if an image exists locally, it had better be in the manifest.
+    store_local_manifest(&config, &manifest_bytes[..])?;
+
+    for entry in &remote_manifest.entries {
         println!("entry: {:?}", entry);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod cli;
 mod config;
 mod curl;
 mod error;
+mod fetch;
 mod manifest;
 
 fn run_init(config_fname: &String) {
@@ -28,6 +29,7 @@ fn run_init(config_fname: &String) {
 
 fn run_fetch(config_fname: &String) {
     println!("Run for {}.", config_fname);
+    fetch::fetch(config_fname).unwrap();
 }
 
 fn main() {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -8,6 +8,7 @@ use base64;
 use error::{Error, Result};
 use std::str;
 
+#[derive(Debug, Eq, PartialEq)]
 pub struct Entry {
     pub version: String,
     pub sha256: [u8; 32],


### PR DESCRIPTION
This implements downloading of the manifest and storing it locally. Basically, we now have a 500-line Rust program that does `curl https://origin/manifest > destination/manifest`!

 * Verify that the new manifest is a superset.
 * Origin url is loaded from the config file.