### PR TITLE
Add a version type

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,8 @@ use std::fmt;
 use std::path::PathBuf;
 use std::vec;
 
+use version::Version;
+
 const USAGE: &'static str = "
 Tako -- Take container image.
 
@@ -78,7 +80,7 @@ pub struct Store {
     pub secret_key: Option<String>,
     pub secret_key_path: Option<PathBuf>,
     pub output_path: PathBuf,
-    pub version: String,
+    pub version: Version,
     pub image_path: PathBuf,
 }
 
@@ -312,7 +314,7 @@ fn parse_store(mut args: ArgIter) -> Result<Cmd, String> {
         secret_key: secret_key,
         secret_key_path: secret_key_path.map(PathBuf::from),
         output_path: PathBuf::from(output_path),
-        version: version,
+        version: Version::new(version),
         image_path: PathBuf::from(image_path),
     };
 
@@ -365,6 +367,7 @@ fn unexpected<T>(arg: Arg<String>) -> Result<T, String> {
 mod test {
     use std::path::PathBuf;
     use super::{Cmd, Store, parse};
+    use version::Version;
 
     fn parse_slice(args: &[&'static str]) -> Result<Cmd, String> {
         let argv = args.iter().map(|s| String::from(*s)).collect();
@@ -432,7 +435,7 @@ mod test {
             secret_key: Some("secret".to_string()),
             secret_key_path: None,
             output_path: PathBuf::from("/tmp"),
-            version: "3.7.5".to_string(),
+            version: Version::from("3.7.5"),
             image_path: PathBuf::from("out.img"),
         };
         let expected = Ok(Cmd::Store(store));

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,8 @@ use std::result;
 
 use base64;
 
+use version::Version;
+
 #[derive(Debug)]
 pub enum Error {
     /// Error in config file on a given line.
@@ -36,6 +38,14 @@ pub enum Error {
 
     /// Curl failed in some way.
     DownloadError(String),
+
+    /// Store failed because the version already exists.
+    ///
+    /// This can happen for two reasons:
+    ///
+    ///  * The version exists and has a different digest.
+    ///  * Two versions differ only by separators, e.g. `1.0` and `1-0`.
+    Duplicate(Version),
 
     /// IO error.
     IoError(io::Error),

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -94,9 +94,5 @@ pub fn fetch(config_fname: &str) -> Result<()> {
     // other hand, if an image exists locally, it had better be in the manifest.
     manifest::store_local(&config.destination, &manifest_bytes[..])?;
 
-    for entry in &remote_manifest.entries {
-        println!("entry: {:?}", entry);
-    }
-
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ mod fetch;
 mod manifest;
 mod store;
 mod util;
+mod version;
 
 fn run_init(config_fname: &String) {
     println!("Run for {}.", config_fname);

--- a/src/store.rs
+++ b/src/store.rs
@@ -90,7 +90,7 @@ pub fn store(store: Store) -> Result<()> {
     perms.set_readonly(true);
     fs::set_permissions(&target_fname, perms)?;
 
-    println!("{} -> {}", store.version, digest_hex);
+    println!("{} -> {}", store.version.as_str(), digest_hex);
 
     // Add the new entry to the manifest.
     let entry = Entry {

--- a/src/store.rs
+++ b/src/store.rs
@@ -97,9 +97,7 @@ pub fn store(store: Store) -> Result<()> {
         version: store.version,
         digest: digest,
     };
-    manifest.entries.push(entry);
-
-    // TODO: Sort and deduplicate. Verify that versions do not occur twice.
+    manifest.insert(entry)?;
 
     // And finally store the new manifest. Write to a temporary file, then swap
     // it into place.

--- a/src/version.rs
+++ b/src/version.rs
@@ -22,7 +22,7 @@ enum Part {
 
 /// A parsed version string that can be ordered.
 #[derive(Debug)]
-struct Version {
+pub struct Version {
     string: String,
     parts: Vec<Part>,
 }
@@ -81,6 +81,17 @@ impl Version {
             Part::Num(..) => "",
             Part::Str(begin, end) => &self.string[begin as usize..end as usize],
         }
+    }
+
+    /// Format the version as a string.
+    pub fn as_str(&self) -> &str {
+        &self.string[..]
+    }
+}
+
+impl<'a> From<&'a str> for Version {
+    fn from(v: &'a str) -> Version {
+        Version::new(String::from(v))
     }
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -26,7 +26,7 @@ enum Part {
 /// following versions are all equal: `1.0.0`, `1_0_0`, and `1.0-0`. To compare
 /// for string equality, use `as_str()`. Semantic equality does take the number
 /// of parts into account. The following versions are not equal: `1`, `1.0`.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Version {
     string: String,
     parts: Vec<Part>,

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,98 @@
+// Tako -- Take container image.
+// Copyright 2018 Arian van Putten, Ruud van Asseldonk, Tako Marks.
+
+//! Version parsing and ordering utilities.
+
+use std::str::FromStr;
+
+/// Designates a part of a version string.
+#[derive(Debug, Eq, PartialEq)]
+enum Part {
+    /// A numeric part.
+    Num(u64),
+
+    /// A string (begin index and end index, inclusive and exclusive).
+    ///
+    /// We store two 32-bit integers rather than usizes, to ensure that this
+    /// variant has the same size as `Num`. A version string is not larger than
+    /// 4 GiB anyway, so this is fine.
+    Str(u32, u32),
+}
+
+/// A parsed version string that can be ordered.
+#[derive(Debug, Eq, PartialEq)]
+struct Version {
+    string: String,
+    parts: Vec<Part>,
+}
+
+impl Version {
+    fn push(parts: &mut Vec<Part>, string: &str, begin: usize, end: usize) {
+        // Skip empty parts.
+        if begin == end { return }
+
+        let is_numeric = string
+            .as_bytes()[begin..end]
+            .iter()
+            .all(|b| b.is_ascii_digit());
+
+        if is_numeric {
+            // The parse will not fail, as we just established that the string
+            // consists of ascii digits only.
+            // TODO: There might be an overflow issue though. Limit string
+            // length as a crude solution?
+            let n = u64::from_str(&string[begin..end]).unwrap();
+            parts.push(Part::Num(n));
+        } else {
+            parts.push(Part::Str(begin as u32, end as u32))
+        }
+    }
+
+    pub fn new(version: String) -> Version {
+        let mut parts = Vec::new();
+        let mut begin = 0;
+        for (i, b) in version.as_bytes().iter().enumerate() {
+            match *b {
+                b'.' | b'-' | b'_' => {
+                    // End the current part.
+                    Version::push(&mut parts, &version, begin, i);
+                    // Begin past the separator. The separator itself is
+                    // not stored.
+                    begin = i + 1;
+                }
+                _ => {},
+            }
+        }
+
+        // Add the remaning part.
+        Version::push(&mut parts, &version, begin, version.len());
+
+        Version {
+            string: version,
+            parts: parts,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Part, Version};
+
+    #[test]
+    fn version_new_handles_empty() {
+        let v = Version::new("".to_string());
+        assert_eq!(v.parts.len(), 0);
+    }
+
+    #[test]
+    fn version_new_handles_single_numeric_component() {
+        let v = Version::new("13".to_string());
+        assert_eq!(v.parts[0], Part::Num(13));
+    }
+
+    #[test]
+    fn version_new_handles_single_string_component() {
+        let v = Version::new("44cc".to_string());
+        assert_eq!(v.parts[0], Part::Str(0, 4));
+    }
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -21,6 +21,11 @@ enum Part {
 }
 
 /// A parsed version string that can be ordered.
+///
+/// Equality on versions is semantic equality, not string equality. The
+/// following versions are all equal: `1.0.0`, `1_0_0`, and `1.0-0`. To compare
+/// for string equality, use `as_str()`. Semantic equality does take the number
+/// of parts into account. The following versions are not equal: `1`, `1.0`.
 #[derive(Debug)]
 pub struct Version {
     string: String,
@@ -154,27 +159,27 @@ mod test {
 
     #[test]
     fn version_new_handles_empty() {
-        let v = Version::new("".to_string());
+        let v = Version::from("");
         assert_eq!(v.parts.len(), 0);
     }
 
     #[test]
     fn version_new_handles_single_numeric_component() {
-        let v = Version::new("13".to_string());
+        let v = Version::from("13");
         assert_eq!(v.parts[0], Part::Num(13));
     }
 
     #[test]
     fn version_new_handles_single_string_component() {
-        let v = Version::new("44cc".to_string());
+        let v = Version::from("44cc");
         assert_eq!(v.parts[0], Part::Str(0, 4));
     }
 
     #[test]
     fn version_new_handles_two_components() {
-        let u = Version::new("1.0".to_string());
-        let v = Version::new("1-0".to_string());
-        let w = Version::new("1_0".to_string());
+        let u = Version::from("1.0");
+        let v = Version::from("1-0");
+        let w = Version::from("1_0");
         assert_eq!(&u.parts, &[Part::Num(1), Part::Num(0)]);
         assert_eq!(&v.parts, &u.parts);
         assert_eq!(&w.parts, &u.parts);
@@ -182,28 +187,48 @@ mod test {
 
     #[test]
     fn version_eq_ignores_separator() {
-        let u = Version::new("1.0".to_string());
-        let v = Version::new("1-0".to_string());
-        let w = Version::new("1_0".to_string());
+        let u = Version::from("1.0");
+        let v = Version::from("1-0");
+        let w = Version::from("1_0");
         assert_eq!(u, v);
         assert_eq!(v, w);
     }
 
     #[test]
+    fn version_eq_handles_pairwise_equal() {
+        let versions = [
+            Version::from("1.0.0"),
+            Version::from("1_0.0"),
+            Version::from("1.0-0"),
+            Version::from("1.0.000"),
+            Version::from("001.0.000"),
+            Version::from("1.0.0."),
+            Version::from("1.0.0____"),
+            Version::from("1..0.0"),
+            Version::from("1._.0.0"),
+        ];
+        for i in 0..versions.len() {
+            for j in 0..versions.len() {
+                assert_eq!(versions[i], versions[j]);
+            }
+        }
+    }
+
+    #[test]
     fn version_eq_handles_pairwise_inequal() {
         let versions = [
-            Version::new("0".to_string()),
-            Version::new("1".to_string()),
-            Version::new("2".to_string()),
-            Version::new("a".to_string()),
-            Version::new("0.0".to_string()),
-            Version::new("1.1".to_string()),
-            Version::new("1.2".to_string()),
-            Version::new("1.a".to_string()),
-            Version::new("1.0".to_string()),
-            Version::new("2.0".to_string()),
-            Version::new("a.0".to_string()),
-            Version::new("0.0.0".to_string()),
+            Version::from("0"),
+            Version::from("1"),
+            Version::from("2"),
+            Version::from("a"),
+            Version::from("0.0"),
+            Version::from("1.1"),
+            Version::from("1.2"),
+            Version::from("1.a"),
+            Version::from("1.0"),
+            Version::from("2.0"),
+            Version::from("a.0"),
+            Version::from("0.0.0"),
         ];
         for i in 0..versions.len() {
             for j in 0..versions.len() {
@@ -220,27 +245,27 @@ mod test {
     fn version_cmp_handles_pairwise_less() {
         // These versions are ordered in ascending order.
         let versions = [
-            Version::new("".to_string()),
-            Version::new("a".to_string()),
-            Version::new("a.b".to_string()),
-            Version::new("a.0".to_string()),
-            Version::new("a.0.0".to_string()),
-            Version::new("a.1".to_string()),
-            Version::new("b".to_string()),
-            Version::new("b.0".to_string()),
-            Version::new("b.1.3".to_string()),
-            Version::new("c".to_string()),
-            Version::new("0".to_string()),
-            Version::new("0.a".to_string()),
-            Version::new("0.0".to_string()),
-            Version::new("0.1".to_string()),
-            Version::new("0.1-a".to_string()),
-            Version::new("0.1.1".to_string()),
-            Version::new("1".to_string()),
-            Version::new("1.0".to_string()),
-            Version::new("1.0.1".to_string()),
-            Version::new("1.1".to_string()),
-            Version::new("2".to_string()),
+            Version::from(""),
+            Version::from("a"),
+            Version::from("a.b"),
+            Version::from("a.0"),
+            Version::from("a.0.0"),
+            Version::from("a.1"),
+            Version::from("b"),
+            Version::from("b.0"),
+            Version::from("b.1.3"),
+            Version::from("c"),
+            Version::from("0"),
+            Version::from("0.a"),
+            Version::from("0.0"),
+            Version::from("0.1"),
+            Version::from("0.1-a"),
+            Version::from("0.1.1"),
+            Version::from("1"),
+            Version::from("1.0"),
+            Version::from("1.0.1"),
+            Version::from("1.1"),
+            Version::from("2"),
         ];
         for i in 0..versions.len() {
             for j in 0..versions.len() {


### PR DESCRIPTION
Add a `Version` type that represents a version string like `1.13.17-beta.3` semantically as `[Num(1), Num(13), Num(17), Str("beta"), Num(3)]`, that we can use to order by version and check compatibility.

I had to make a few changes to this type to implement bounds in a nice way in the next pull request, but this is a good start.