### PR TITLE
Make unit restart configuration consistent with systemd

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,9 +3,12 @@
 The version numbers in this list should not be interpreted literally. Rather,
 they indicate near-term versus long-term goals.
 
-## 0.1
+## Done
 
  * Rename `RestartUnit=` to `Restart=`.
+
+## 0.1
+
  * Allow space-separated units in `Restart=`.
  * Implement `tako fetch --init`.
  * Ensure it runs on CoreOS.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,10 +6,10 @@ they indicate near-term versus long-term goals.
 ## Done
 
  * Rename `RestartUnit=` to `Restart=`.
+ * Allow space-separated units in `Restart=`.
 
 ## 0.1
 
- * Allow space-separated units in `Restart=`.
  * Implement `tako fetch --init`.
  * Ensure it runs on CoreOS.
  * Check for spaces in versions.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ per image. Config files follow the same syntax as systemd unit files.
     Version=1.*
 
     # Restart app-foo after a new image has been fetched.
-    RestartUnit=app-foo.service
+    Restart=app-foo.service
 
 ## Options
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,13 +97,13 @@ impl Config {
                     "Destination" => {
                         destination = Some(PathBuf::from(value));
                     }
-                    "RestartUnit" => {
+                    "Restart" => {
                         restart_units.push(String::from(value));
                     }
                     _ => {
                         let msg = "Unknown key. Expected one of \
                             'Origin', 'PublicKey', 'Version', 'Destination', \
-                            or 'RestartUnit'.";
+                            or 'Restart'.";
                         return Err(Error::InvalidConfig(lineno, msg))
                     }
                 }
@@ -176,7 +176,7 @@ mod test {
             "PublicKey=8+r5DKNN/cwI+h0oHxMtgdyND3S/5xDLHQu0hFUmq+g=",
             "Version=*",
             "Destination=/var/lib/images/app-foo",
-            "RestartUnit=foo",
+            "Restart=foo",
         ];
         let config = Config::parse(&config_lines).unwrap();
         assert_eq!(&config.restart_units[..], &["foo"]);
@@ -189,8 +189,8 @@ mod test {
             "PublicKey=8+r5DKNN/cwI+h0oHxMtgdyND3S/5xDLHQu0hFUmq+g=",
             "Version=1.*",
             "Destination=/var/lib/images/app-foo",
-            "RestartUnit=foo",
-            "RestartUnit=bar",
+            "Restart=foo",
+            "Restart=bar",
         ];
         let config = Config::parse(&config_lines).unwrap();
         assert_eq!(&config.restart_units[..], &["foo", "bar"]);

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,7 +98,9 @@ impl Config {
                         destination = Some(PathBuf::from(value));
                     }
                     "Restart" => {
-                        restart_units.push(String::from(value));
+                        for unit in value.split(|ch| ch == ' ') {
+                            restart_units.push(String::from(unit));
+                        }
                     }
                     _ => {
                         let msg = "Unknown key. Expected one of \
@@ -194,6 +196,33 @@ mod test {
         ];
         let config = Config::parse(&config_lines).unwrap();
         assert_eq!(&config.restart_units[..], &["foo", "bar"]);
+    }
+
+    #[test]
+    pub fn config_with_2_space_separated_restart_units_is_parsed() {
+        let config_lines = [
+            "Origin=https://images.example.com/app-foo",
+            "PublicKey=8+r5DKNN/cwI+h0oHxMtgdyND3S/5xDLHQu0hFUmq+g=",
+            "Version=1.*",
+            "Destination=/var/lib/images/app-foo",
+            "Restart=foo bar",
+        ];
+        let config = Config::parse(&config_lines).unwrap();
+        assert_eq!(&config.restart_units[..], &["foo", "bar"]);
+    }
+
+    #[test]
+    pub fn config_with_3_mixed_separated_restart_units_is_parsed() {
+        let config_lines = [
+            "Origin=https://images.example.com/app-foo",
+            "PublicKey=8+r5DKNN/cwI+h0oHxMtgdyND3S/5xDLHQu0hFUmq+g=",
+            "Version=1.*",
+            "Destination=/var/lib/images/app-foo",
+            "Restart=foo bar",
+            "Restart=baz",
+        ];
+        let config = Config::parse(&config_lines).unwrap();
+        assert_eq!(&config.restart_units[..], &["foo", "bar", "baz"]);
     }
 
     #[test]

--- a/tests/run.py
+++ b/tests/run.py
@@ -64,7 +64,7 @@ def test(description):
     try:
         yield
     except:
-        print('not ok {} {}'.format(test_number, description))
+        print('not ok {:2} {}'.format(test_number, description))
         exc_type, error, tb = sys.exc_info()
         _filename, line, _function, statement = traceback.extract_tb(tb)[-1]
         print('# line {}: {}'.format(line, statement))
@@ -72,7 +72,7 @@ def test(description):
             error.print_details()
         test_failed = True
     else:
-        print('ok {} {}'.format(test_number, description))
+        print('ok {:2} {}'.format(test_number, description))
 
     # When output of this script is piped into a TAP runner such as 'prove',
     # Python would buffer stdout, which means we don't see test results as they

--- a/tests/run.py
+++ b/tests/run.py
@@ -74,6 +74,11 @@ def test(description):
     else:
         print('ok {} {}'.format(test_number, description))
 
+    # When output of this script is piped into a TAP runner such as 'prove',
+    # Python would buffer stdout, which means we don't see test results as they
+    # happen, only later when the buffer is full. Flush for responsiveness.
+    sys.stdout.flush()
+
 
 def run_server():
     port = 8117


### PR DESCRIPTION
* Name the option `Restart=` rather than `RestartUnit=`; systemd unit files have `Requires=`, not `RequiresUnit=`.
* Accept a list of space-separated units in addition to multiple keys, just like systemd does.
* Drive-by test script improvements.