### PR TITLE
Add Nix expression to build Tako

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,38 @@
+{ pkgs ?
+  # Default to a pinned version of Nixpkgs. The actual revision of the Nixpkgs
+  # repository is stored in a separate file (as a fetchTarball Nix expression).
+  # We then fetch that revision from Github and import it. The revision should
+  # periodically be updated to be the last commit of Nixpkgs.
+  import (import ./nixpkgs-pinned.nix) {}
+}:
+
+with pkgs;
+
+let
+  # Define the unpack phase manually, because setting src = ./. includes too
+  # much, and setting up filters is tedious.
+  sources = stdenv.mkDerivation {
+    name = "tako-src";
+    phases = [ "unpackPhase" ];
+    unpackPhase = ''
+      mkdir $out
+      cp ${./Cargo.toml} $out/Cargo.toml
+      cp ${./Cargo.lock} $out/Cargo.lock
+      cp -r ${./src} $out/src
+    '';
+  };
+in
+  rustPlatform.buildRustPackage rec {
+    name = "tako-${version}";
+    version = "0.0.0";
+    src = sources;
+    cargoSha256 = "1f7n67xjv268ciw434bicnmc341lgwa0is80r61p6hx9jfn0rjp3";
+    nativeBuildInputs = [ curl libsodium pkgconfig ];
+    meta = with stdenv.lib; {
+      description = "Updater for single files.";
+      homepage = https://github.com/ruuda/tako;
+      license = licenses.asl20;
+      maintainers = [ maintainers.ruuda ];
+      platforms = platforms.linux;
+    };
+  }

--- a/nixpkgs-pinned.nix
+++ b/nixpkgs-pinned.nix
@@ -1,0 +1,4 @@
+fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/ca2ba44cab47767c8127d1c8633e2b581644eb8f.tar.gz";
+  sha256 = "1jg7g6cfpw8qvma0y19kwyp549k1qyf11a5sg6hvn6awvmkny47v";
+}


### PR DESCRIPTION
Attempt at https://github.com/ruuda/tako/pull/20#discussion_r207729872, however it is not as simple as I had hoped:

* We can use `rustPlatform.buildRustPackage` and that works, but it does not run the tests. Setting `doCheck = true` does not help. Also, I don't know how to make it link libsodium statically this way.
* We can make a custom derivation that invokes Cargo, with `$HOME` somewhere in the build directory, however Cargo gets stuck updating the registry (there is just no other output, then after a few minutes I kill it).

So this could be nice for building a Nixpkgs package, but for CI we also need to run the tests. Any ideas @arianvp?